### PR TITLE
Added missing command-line arguments

### DIFF
--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -10,7 +10,8 @@ var load = Module._load;
 
 module.exports = function(options, settings, doneCallback) {
   function spawnNightwatch(done) {
-    var argv = $.pick(options.argv, ['tag', 'test', 'filter', 'verbose', 'group', 'skipgroup']);
+    var argv = $.pick(options.argv, ['config', 'env', 'tag', 'test', 'testcase', 'filter', 'verbose',
+                   'group', 'skipgroup', 'skiptags', 'output', 'reporter', 'retries', 'suiteRetries']);
 
     // I found this hack for avoiding intermediate .json files
     var HACK_ID = '__NWRUN_FAKED_CONFIG_BECAUSE_YOLO__' + Math.random();


### PR DESCRIPTION
This is to add support for all command line arguments that nightwatch currently have.
Also this is to fix this: [Issue 61](https://github.com/gextech/grunt-nightwatch/issues/61)
